### PR TITLE
docs: Add a first definition to glossary. #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Este projeto se destina a ter um glossário das principais palavras para auxilia
 
 ### [Ansible](https://docs.ansible.com/)
 
-Ansible é uma ferramenta de automação de TI que automatiza o provisionamento em nuvem, o gerenciamento de configurações, a implantação de aplicativos e a orquestração intra-serviços.
+Ansible é uma ferramenta de [Código Aberto](###Código-Aberto) para automação de TI que automatiza o provisionamento em nuvem, o gerenciamento de configurações, a implantação de aplicativos e a orquestração intra-serviços.
 
 ## B
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,91 @@
-# glossario
+# Glossario da mentoriaIaC de A a Z
+
+Este projeto se destina a ter um glossario das principais palavras para auxiliar os participantes da MentoriaIaC.
+
+* O termos estão em ordem alfabetica sendo eles em Português, Inglês ou Aportuguesados
+* O significado do termo está em Português
+* Cada termo terá um link de referencia e se for contundente terá um artigo sobre no blog da MentoriaIaC que será linkado também no verbete
+
+## Escolha a letra do Alfabeto
+
+[A](##a) | [B](##b) | [C](##c) | [D](##d) | [E](##e) | [F](##f) | [G](##g) | [H](##h) | [I](##i) | [J](##j) | [K](##k) | [L](##l) | [M](##m) | [N](##n) | [O](##o) | [P](##p) | [Q](##q) | [R](##r) | [S](##s) | [T](##t) | [U](##u) | [V](##v) | [W](##w) | [X](##x) | [Y](##y) | [Z](##z) |
+
+## A
+
+### [Ansible](https://docs.ansible.com/)
+
+Ansible é uma ferramenta de automação de TI que automatiza o provisionamento em nuvem, o gerenciamento de configurações, a implantação de aplicativos e a orquestração intra-serviços.
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+### [GCP](https://cloud.google.com/docs?hl=pt-br)
+
+GCP é o acronimo para Google Cloud Platform, é o provedor de Infraestrutura da Google
+
+## H
+
+## I
+
+### [IaC](https://pt.wikipedia.org/wiki/Infraestrutura_como_C%C3%B3digo)
+
+IaC, Infraestrutura como Codigo ou em inglês Infrastructure as Code, é o gerenciamento do provisionamento de Infraestrutura utilizando arquivos versionaveis e auditaveis.
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+
+## O
+
+## P
+
+### [Packer](https://www.packer.io/docs)
+
+Packer é uma ferramenta de **Codigo Aberto** utilizada para construir imagens no provedor de cloud. Ela é uma das referencias para a [Infraestrutura Imutavel](###Infraestrutura-Imutavel)
+
+## Q
+
+## R
+
+## S
+
+## T
+
+### [Terraform](https://www.terraform.io/intro/index.html)
+
+Terraform é uma ferramenta de **Codigo Aberto** utilizada para construir, modificar e versionar infraestrutura de forma segura e eficiente. Ela é uma das referencias para a Infraestrutura como Codigo ou [IaC](###IaC)
+
+## U
+
+## V
+
+## X
+
+## Y
+
+## Z
+
+## Como contribuir
+
+* Fork o projeto
+* Clone o fork projeto no seu usuário
+* Crie uma branch para realizar a modificação
+* Adicione o termo sugerido em ordem alfabetica
+* Suba as modificações com `git push`
+* E crie um PR para o repositório [github.com/mentoriaiac/glossario.git](https://github.com/mentoriaiac/glossario.git)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Glossario da mentoriaIaC de A a Z
+# Glossário da MentoriaIaC de A a Z
 
-Este projeto se destina a ter um glossario das principais palavras para auxiliar os participantes da MentoriaIaC.
+Este projeto se destina a ter um glossário das principais palavras para auxiliar os participantes da Mentoria IaC.
 
-* O termos estão em ordem alfabetica sendo eles em Português, Inglês ou Aportuguesados
+* O termos estão em ordem alfabética sendo eles em Português, Inglês ou Aportuguesados
 * O significado do termo está em Português
-* Cada termo terá um link de referencia e se for contundente terá um artigo sobre no blog da MentoriaIaC que será linkado também no verbete
+* Cada termo terá um link de referencia e se for contundente terá um artigo sobre no blog da Mentoria IaC que será linkado também no verbete
 
 ## Escolha a letra do Alfabeto
 
@@ -20,6 +20,10 @@ Ansible é uma ferramenta de automação de TI que automatiza o provisionamento 
 
 ## C
 
+### [Código Aberto](https://pt.wikipedia.org/wiki/C%C3%B3digo_aberto)
+
+Código Aberto é um termo que se refere a um software cujo código está disponível para download por qualquer pessoa e a uma filosofia de criação de aplicativos voltada para a colaboração entre desenvolvedores.
+
 ## D
 
 ## E
@@ -30,7 +34,7 @@ Ansible é uma ferramenta de automação de TI que automatiza o provisionamento 
 
 ### [GCP](https://cloud.google.com/docs?hl=pt-br)
 
-GCP é o acronimo para Google Cloud Platform, é o provedor de Infraestrutura da Google
+GCP é o acrônimo para Google Cloud Platform, é o provedor de Infraestrutura da Google
 
 ## H
 
@@ -38,7 +42,7 @@ GCP é o acronimo para Google Cloud Platform, é o provedor de Infraestrutura da
 
 ### [IaC](https://pt.wikipedia.org/wiki/Infraestrutura_como_C%C3%B3digo)
 
-IaC, Infraestrutura como Codigo ou em inglês Infrastructure as Code, é o gerenciamento do provisionamento de Infraestrutura utilizando arquivos versionaveis e auditaveis.
+IaC, Infraestrutura como Código ou em inglês Infrastructure as Code, é o gerenciamento do provisionamento de Infraestrutura utilizando arquivos versionaveis e auditaveis.
 
 ## J
 
@@ -50,14 +54,13 @@ IaC, Infraestrutura como Codigo ou em inglês Infrastructure as Code, é o geren
 
 ## N
 
-
 ## O
 
 ## P
 
 ### [Packer](https://www.packer.io/docs)
 
-Packer é uma ferramenta de **Codigo Aberto** utilizada para construir imagens no provedor de cloud. Ela é uma das referencias para a [Infraestrutura Imutavel](###Infraestrutura-Imutavel)
+Packer é uma ferramenta de [Código Aberto](###Código-Aberto) utilizada para construir imagens no provedor de cloud. Ela é uma das referencias para a [Infraestrutura Imutavel](###Infraestrutura-Imutavel)
 
 ## Q
 
@@ -69,7 +72,7 @@ Packer é uma ferramenta de **Codigo Aberto** utilizada para construir imagens n
 
 ### [Terraform](https://www.terraform.io/intro/index.html)
 
-Terraform é uma ferramenta de **Codigo Aberto** utilizada para construir, modificar e versionar infraestrutura de forma segura e eficiente. Ela é uma das referencias para a Infraestrutura como Codigo ou [IaC](###IaC)
+Terraform é uma ferramenta de [Código Aberto](###Código-Aberto) utilizada para construir, modificar e versionar infraestrutura de forma segura e eficiente. Ela é uma das referencias para a Infraestrutura como Código ou [IaC](###IaC)
 
 ## U
 
@@ -86,6 +89,6 @@ Terraform é uma ferramenta de **Codigo Aberto** utilizada para construir, modif
 * Fork o projeto
 * Clone o fork projeto no seu usuário
 * Crie uma branch para realizar a modificação
-* Adicione o termo sugerido em ordem alfabetica
+* Adicione o termo sugerido em ordem alfabética
 * Suba as modificações com `git push`
-* E crie um PR para o repositório [github.com/mentoriaiac/glossario.git](https://github.com/mentoriaiac/glossario.git)
+* E crie um PR para o repositório [github.com/mentoriaiac/glossário.git](https://github.com/mentoriaiac/glossário.git)


### PR DESCRIPTION
Inclusao da primeira definiçao para glossario da mentoriaIaC.
Depois sera necessario trabalhar mais nos verbetes.
Mas a ideia e que um verbete se link no outro para termos uma definiçao
mais completa possivel do termo.

O repositorio se destina para todas as pessoas da MentoriaIaC.
Pensei em deixar ele todo em Portugues para ser acessivel para todos os
membros da Mentoria.

Posteriormente, podemos ter outros READMEs por idioma, ai teriamos a
descriçao do verbete em ingles por exemplo.

Como primeira referencia utilizei o respositorio
https://github.com/Lets-DevOps/devops-glossary.